### PR TITLE
Refactor and style #2

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -31,8 +31,11 @@ class App extends Component {
     ]
 
     return (
-      <div className="App" style={{ height: '100vh', background: '#1A1A1A'}}>
+      <div className="App" style={{ height: '100vh', background: '#1A1A1A', paddingRight: '20px'}}>
+      <div style={{display: 'grid', gridTemplateColumns: '1fr 1fr', gridGap: '10px'}}>
         <ReactDropdown data={sampleList} placeholder='search or select'/>
+        <ReactDropdown data={sampleList} placeholder='search or select'/>
+      </div>
         <div style={{color: 'white', padding: '10px'}}>
           Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source. Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of "de Finibus Bonorum et Malorum" (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, "Lorem ipsum dolor sit amet..", comes from a line in section 1.10.32.
           The standard chunk of Lorem Ipsum used since the 1500s is reproduced below for those interested. Sections 1.10.32 and 1.10.33 from "de Finibus Bonorum et Malorum" by Cicero are also reproduced in their exact original form, accompanied by English versions from the 1914 translation by H. Rackham.

--- a/src/dropdown/ReactDropdown.jsx
+++ b/src/dropdown/ReactDropdown.jsx
@@ -88,15 +88,18 @@ export default class ReactDropdown extends Component {
     ) : null;
 
     return (
-      <div ref="dropdownbox" className="react-dropdown" onFocus={this.handleOnFocus} onChange={this.handleOnTextChange} onKeyDown={this.handleOnKeyDown} >
-        <div className="search">
-          <Textbox className="search-box" placeholder={this.props.placeholder} value={this.state.textInput} />
-          <div tabIndex="-1" className="search-dd">
-            <span className='arrow-up'></span>
-            <span className='arrow-down'></span>
+      <div ref={node => this.node = node}>
+        <div ref="dropdownbox" className="react-dropdown" onFocus={this.handleOnFocus} onChange={this.handleOnTextChange} onKeyDown={this.handleOnKeyDown} >
+          <div className="search">
+            <Textbox className="search-box" placeholder={this.props.placeholder} value={this.state.textInput} />
+            <div tabIndex="-1" className="search-dd">
+              <span className='arrow-up'></span>
+              <span className='arrow-down'></span>
+            </div>
           </div>
+          {dropdown}
         </div>
-        {dropdown}
+      
       </div>
     );
   }
@@ -248,11 +251,11 @@ export default class ReactDropdown extends Component {
   }
 
   componentDidMount() {
-    document.addEventListener('click', this.handleClick);
+    document.addEventListener('click', this.handleClick, false);
   }
 
   componentWillUnmount() {
-    document.removeEventListener('click', this.handleClick);
+    document.removeEventListener('click', this.handleClick, false);
   }
 
   
@@ -269,11 +272,16 @@ export default class ReactDropdown extends Component {
     
     // if there are multiple dropdowns rendered on a single page
     // will this logic create a problem?
-    let found = e.path.find(el => el.className === "react-dropdown")
-    if (!!!found) {
-      this.closeDropdown();
-      this.resetSelection();
+    // let found = e.path.find(el => el.className === "react-dropdown")
+    // if (!!!found) {
+    //   this.closeDropdown();
+    //   this.resetSelection();
+    // }
+    if (this.node.contains(e.target)) {
+      return
     }
+    this.closeDropdown();
+    this.resetSelection();
   }
 
   //https://codepen.io/takatama/pen/mVvbqx

--- a/src/dropdown/react-dropdown2.scss
+++ b/src/dropdown/react-dropdown2.scss
@@ -73,6 +73,9 @@ $dropdown-color: #383838;
     flex-direction: column;
     top: 4px;
     margin-right: 5px;
+    &:focus {
+      outline: none;
+    }
     .arrow-up {
       width: 0; 
       height: 0; 

--- a/src/dropdown/react-dropdown2.scss
+++ b/src/dropdown/react-dropdown2.scss
@@ -3,7 +3,7 @@ $dropdown-color: #383838;
 .react-dropdown {
   position: relative;
   display: inline-block;
-  width: 40%;
+  width: 100%;
   margin: 10px;
   box-sizing: border-box;
 


### PR DESCRIPTION
- Wrapped ReactDropdown in a div and passed it a ref that set this.node to equal the component's node.  Then modified handleOnClick to determine if the target of the click is contained in this.node.  This allows for multiple dropdowns to open and close independent from one another.
- removed the default browser focus outline from the dropdown arrows